### PR TITLE
fix for the CPU device

### DIFF
--- a/6/04_encoder_decoder_torch.py
+++ b/6/04_encoder_decoder_torch.py
@@ -189,7 +189,7 @@ if __name__ == '__main__':
         use_teacher_forcing = (random.random() < teacher_forcing_rate)
         model.train()
         preds = model(x, t, use_teacher_forcing=use_teacher_forcing)
-        loss = compute_loss(t.view(-1),
+        loss = compute_loss(t.contiguous().view(-1),
                             preds.view(-1, preds.size(-1)))
 
         optimizer.zero_grad()
@@ -201,7 +201,7 @@ if __name__ == '__main__':
     def val_step(x, t):
         model.eval()
         preds = model(x, t, use_teacher_forcing=False)
-        loss = compute_loss(t.view(-1),
+        loss = compute_loss(t.contiguous().view(-1),
                             preds.view(-1, preds.size(-1)))
 
         return loss, preds

--- a/6/06_attention_torch.py
+++ b/6/06_attention_torch.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
         use_teacher_forcing = (random.random() < teacher_forcing_rate)
         model.train()
         preds = model(x, t, use_teacher_forcing=use_teacher_forcing)
-        loss = compute_loss(t.view(-1),
+        loss = compute_loss(t.contiguous().view(-1),
                             preds.view(-1, preds.size(-1)))
 
         optimizer.zero_grad()
@@ -204,7 +204,7 @@ if __name__ == '__main__':
     def val_step(x, t):
         model.eval()
         preds = model(x, t, use_teacher_forcing=False)
-        loss = compute_loss(t.view(-1),
+        loss = compute_loss(t.contiguous().view(-1),
                             preds.view(-1, preds.size(-1)))
 
         return loss, preds


### PR DESCRIPTION
楽しく「詳解ディープラーニング」の第2版を読ませていただいています。

6章の04_encoder_decoder_torch.pyのコードについて、
CPUで動かすとcompute_loss()でエラーが生じましまた。
```
Traceback (most recent call last):
  File "04_encoder_decoder_torch.py", line 224, in <module>
    loss, _ = train_step(x, t)
  File "04_encoder_decoder_torch.py", line 192, in train_step
    loss = compute_loss(t.view(-1),
RuntimeError: invalid argument 2: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Call .contiguous() before .view(). at /pytorch/aten/src/TH/generic/THTensor.cpp:203
```
(device = 'cpu' と明示的に指定するとエラーを再現できると思います。なお、GPUで動かすとエラーはでませんでした。)

p420、 6.3.5.4 モデルの実装  - 3. モデルの学習・評価で述べられているように、転置を行っているtについて .view()を行う前に、contiguous()の処理が必要ではないでしょうか？

同様に、compute_loss()を行っているval_step()、06_attention_torch.pyの箇所も同じく修正をしました。

動作環境 Python 3.6.9、torch==1.1.0